### PR TITLE
Move browser configs and add tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# Project Guidelines
+
+- Always fix the underlying problem instead of masking it with a try block. If a fix is impossible, leave the behavior as is and clearly describe what does not work, why, and what was attempted.
+- Keep modules focused. A new feature should live in its own file to avoid overloading existing ones.
+- Browser engines and their configs are stored in `browser_engines.py`.
+- Engine configs are passed to `BaseAPI` by calling `BrowserEngine.NAME(**options)`.
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,14 +28,15 @@ classifiers = [
     "Topic :: Utilities",
 ]
 dependencies = [
-    "camoufox[geoip]",
+    "playwright",
     "beartype"
 ]
 
 [project.optional-dependencies]
+camoufox = ["camoufox[geoip]"]
 test = [
     "pytest",
-    "pytest-asyncio", 
+    "pytest-asyncio",
     "pytest-xdist"
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-camoufox[geoip]
+playwright
 beartype
 
 pytest

--- a/standard_open_inflation_package/__init__.py
+++ b/standard_open_inflation_package/__init__.py
@@ -7,7 +7,13 @@ Standard Open Inflation Package
 """
 # Импорт основных классов из модульной структуры
 from .models import HttpMethod, Response, Request, Cookie
-from .browser import BaseAPI  
+from .browser import BaseAPI
+from .browser_engines import (
+    BrowserEngine,
+    BaseBrowserConfig,
+    CamoufoxConfig,
+    PlaywrightConfig,
+)
 from .page import Page
 
 # Версия пакета
@@ -17,6 +23,10 @@ __version__ = "0.1.5"
 __all__ = [
     # Основные классы
     'BaseAPI',
+    'BrowserEngine',
+    'BaseBrowserConfig',
+    'CamoufoxConfig',
+    'PlaywrightConfig',
     'Page',
     
     # Модели данных

--- a/standard_open_inflation_package/browser.py
+++ b/standard_open_inflation_package/browser.py
@@ -1,12 +1,16 @@
 import asyncio
-from camoufox import AsyncCamoufox
 import logging
 from beartype import beartype
-from beartype.typing import Union, Optional, Callable, List, TYPE_CHECKING
+from beartype.typing import Optional, Callable, List, TYPE_CHECKING, Union
 from .tools import parse_proxy
 from . import config as CFG
 from .handler import Handler, HandlerSearchSuccess, HandlerSearchFailed
 from .models import Cookie
+from .browser_engines import (
+    BrowserEngine,
+    BaseBrowserConfig,
+)
+
 
 if TYPE_CHECKING:
     pass
@@ -18,15 +22,17 @@ class BaseAPI:
     Класс для загрузки JSON/image/html.
     """
 
-    def __init__(self,
-                 debug:                 bool            = False,
-                 proxy:                 str | None      = None,
-                 autoclose_browser:     bool            = False,
-                 trust_env:             bool            = False,
-                 timeout:               float           = 10.0,
-                 start_func:            Callable | None = None,
-                 request_modifier_func: Callable | None = None
-        ) -> None:
+    def __init__(
+        self,
+        debug: bool = False,
+        proxy: str | None = None,
+        autoclose_browser: bool = False,
+        trust_env: bool = False,
+        timeout: float = 10.0,
+        start_func: Callable | None = None,
+        request_modifier_func: Callable | None = None,
+        browser_engine: BaseBrowserConfig = BrowserEngine.FIREFOX(),
+    ) -> None:
         # Используем property для установки настроек
         self.debug = debug
         self.proxy = proxy
@@ -36,8 +42,11 @@ class BaseAPI:
         self.start_func = start_func
         self.request_modifier_func = request_modifier_func
 
+        self.engine_config = browser_engine
+
         self._browser = None
         self._bcontext = None
+        self._playwright = None
 
         self._logger = logging.getLogger(self.__class__.__name__)
         handler = logging.StreamHandler()
@@ -256,9 +265,18 @@ class BaseAPI:
 
         if include_browser:
             prox = parse_proxy(self.proxy, self.trust_env, self._logger)
-            self._logger.info(CFG.LOGS.OPENING_BROWSER.format(proxy=CFG.LOGS.SYSTEM_PROXY if prox and not self.proxy else prox))
-            self._browser = await AsyncCamoufox(headless=not self.debug, humanize=True, proxy=prox, geoip=True).__aenter__()
-            self._bcontext = await self._browser.new_context()
+            self._logger.info(
+                CFG.LOGS.OPENING_BROWSER.format(
+                    proxy=CFG.LOGS.SYSTEM_PROXY if prox and not self.proxy else prox
+                )
+            )
+
+            browser, ctx_options, extra = await self.engine_config.initialize(
+                prox, self.debug
+            )
+            self._browser = browser
+            self._bcontext = await self._browser.new_context(**ctx_options)
+            self._playwright = extra
             self._logger.info(CFG.LOGS.BROWSER_CONTEXT_OPENED)
             if self.start_func:
                 self._logger.info(CFG.LOGS.START_FUNC_EXECUTING.format(function_name=self.start_func.__name__))
@@ -274,13 +292,15 @@ class BaseAPI:
         include_browser: bool = True
     ) -> None:
         """
-        Close the Camoufox browser if it is open.
+        Close the browser if it is open.
         :param include_browser: close browser if True
         """
         to_close = []
         if include_browser:
             to_close.append("bcontext")
             to_close.append("browser")
+            if self._playwright is not None:
+                to_close.append("playwright")
 
         self._logger.info(CFG.LOGS.PREPARING_TO_CLOSE.format(connections=to_close if to_close else CFG.LOGS.NOTHING))
 
@@ -290,7 +310,8 @@ class BaseAPI:
 
         checks = {
             "browser": lambda a: a is not None,
-            "bcontext": lambda a: a is not None
+            "bcontext": lambda a: a is not None,
+            "playwright": lambda a: a is not None,
         }
 
         for name in to_close:
@@ -299,9 +320,14 @@ class BaseAPI:
                 self._logger.info(CFG.LOGS.CLOSING_CONNECTION.format(connection_name=name))
                 try:
                     if name == "browser":
-                        await attr.__aexit__(None, None, None)
-                    elif name in ["bcontext"]:
+                        if self._playwright is None:
+                            await attr.__aexit__(None, None, None)
+                        else:
+                            await attr.close()
+                    elif name == "bcontext":
                         await attr.close()
+                    elif name == "playwright":
+                        await attr.stop()
                     else:
                         raise ValueError(f"{CFG.ERRORS.UNKNOWN_CONNECTION_TYPE}: {name}")
 

--- a/standard_open_inflation_package/browser_engines.py
+++ b/standard_open_inflation_package/browser_engines.py
@@ -1,0 +1,86 @@
+from dataclasses import dataclass
+from enum import Enum, auto
+from typing import Any, Optional, Tuple
+
+__all__ = [
+    "BrowserEngine",
+    "BaseBrowserConfig",
+    "CamoufoxConfig",
+    "PlaywrightConfig",
+]
+
+
+class BrowserEngine(Enum):
+    CAMOUFOX = auto()
+    FIREFOX = auto()
+    CHROMIUM = auto()
+    WEBKIT = auto()
+
+    def __call__(self, **kwargs) -> "BaseBrowserConfig":
+        if self is BrowserEngine.CAMOUFOX:
+            return CamoufoxConfig(**kwargs)
+        return PlaywrightConfig(engine=self, **kwargs)
+
+
+@dataclass(slots=True)
+class BaseBrowserConfig:
+    headless: Optional[bool] = None
+
+    async def initialize(
+        self, proxy: Optional[str], debug: bool
+    ) -> Tuple[Any, dict, Optional[Any]]:
+        """Launch browser and return (browser, context_options, extra)."""
+        raise NotImplementedError
+
+
+@dataclass(slots=True)
+class CamoufoxConfig(BaseBrowserConfig):
+    humanization: Any = True
+    geoip: bool = True
+
+    async def initialize(
+        self, proxy: Optional[str], debug: bool
+    ) -> Tuple[Any, dict, Optional[Any]]:
+        try:
+            from camoufox import AsyncCamoufox
+        except ImportError as e:
+            print(
+                "Camoufox is not installed. Install with 'pip install standard_open_inflation_package[camoufox]'"
+            )
+            raise
+
+        headless = self.headless if self.headless is not None else not debug
+        browser = await AsyncCamoufox(
+            headless=headless,
+            humanize=self.humanization,
+            proxy=proxy,
+            geoip=self.geoip,
+        ).__aenter__()
+        return browser, {}, None
+
+
+@dataclass(slots=True)
+class PlaywrightConfig(BaseBrowserConfig):
+    engine: BrowserEngine = BrowserEngine.CHROMIUM
+    ignore_https_errors: bool = True
+
+    async def initialize(
+        self, proxy: Optional[str], debug: bool
+    ) -> Tuple[Any, dict, Optional[Any]]:
+        from playwright.async_api import async_playwright
+
+        headless = self.headless if self.headless is not None else not debug
+        playwright = await async_playwright().start()
+        launch_args = {"headless": headless}
+        if proxy:
+            launch_args["proxy"] = proxy
+
+        launcher = {
+            BrowserEngine.CHROMIUM: playwright.chromium,
+            BrowserEngine.FIREFOX: playwright.firefox,
+            BrowserEngine.WEBKIT: playwright.webkit,
+        }[self.engine]
+
+        browser = await launcher.launch(**launch_args)
+        return browser, {"ignore_https_errors": self.ignore_https_errors}, playwright
+

--- a/tests/browser/test_engine_init.py
+++ b/tests/browser/test_engine_init.py
@@ -1,0 +1,47 @@
+import asyncio
+import pytest
+
+from standard_open_inflation_package import BaseAPI
+from standard_open_inflation_package.browser_engines import (
+    BrowserEngine,
+    BaseBrowserConfig,
+    CamoufoxConfig,
+    PlaywrightConfig,
+)
+
+class DummyBrowser:
+    def __init__(self):
+        self.context_kwargs = None
+    async def new_context(self, **kwargs):
+        self.context_kwargs = kwargs
+        return f"context:{kwargs}"
+
+class DummyConfig(BaseBrowserConfig):
+    async def initialize(self, proxy, debug):
+        return DummyBrowser(), {"foo": "bar"}, None
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("cfg", [
+    DummyConfig(),
+])
+async def test_engine_selection(cfg):
+    api = BaseAPI(browser_engine=cfg)
+    await api.new_session()
+    assert isinstance(api._browser, DummyBrowser)
+    assert api._bcontext == "context:{'foo': 'bar'}"
+    await api.close()
+
+
+@pytest.mark.asyncio
+async def test_default_engine_config():
+    assert isinstance(BrowserEngine.CAMOUFOX(), CamoufoxConfig)
+    for e in (BrowserEngine.CHROMIUM, BrowserEngine.FIREFOX, BrowserEngine.WEBKIT):
+        assert isinstance(e(), PlaywrightConfig)
+
+
+@pytest.mark.asyncio
+async def test_default_engine_is_firefox():
+    api = BaseAPI()
+    assert isinstance(api.engine_config, PlaywrightConfig)
+    assert api.engine_config.engine == BrowserEngine.FIREFOX
+


### PR DESCRIPTION
## Summary
- factor browser engine classes into `browser_engines.py`
- update `BaseAPI` to import configs from new module
- export browser configs from package `__init__`
- add guidelines in `AGENTS.md`
- test initialization of different engines
- change API to accept config objects directly and default to Firefox
- move Camoufox dependency to optional extras

## Testing
- `pytest -q tests/browser/test_engine_init.py`
- `pytest -q` *(fails: playwright errors due to missing browsers)*

------
https://chatgpt.com/codex/tasks/task_e_684accb5cab0832fb952aae0f4d5218f