### PR TITLE
Add Execute modifier for Handler

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@ from standard_open_inflation_package import BaseAPI, Request, Response, HttpMeth
 from standard_open_inflation_package.exceptions import NetworkError
 from standard_open_inflation_package import config as CFG
 from standard_open_inflation_package.handler import Handler, ExpectedContentType, HandlerSearchSuccess, HandlerSearchFailed
+from standard_open_inflation_package.execute import Execute
 from standard_open_inflation_package.browser_engines import BrowserEngine
 from pprint import pprint
 import time
@@ -49,7 +50,10 @@ class Sample:
         return await self.base_page.direct_fetch(
             url="https://5ka.ru/product/produkt-rassolnyy-sirtaki-original-dlya-grecheskog--3483307/",
             wait_selector=".priceContainer_productCent__J1bRL",
-            handlers=Handler.SIDE(expected_content=ExpectedContentType.IMAGE, max_responses=1)
+            handlers=Handler.SIDE(
+                expected_content=ExpectedContentType.IMAGE,
+                execute=Execute.RETURN(1),
+            )
         )
 
     async def get_categories(self):

--- a/standard_open_inflation_package/__init__.py
+++ b/standard_open_inflation_package/__init__.py
@@ -7,6 +7,7 @@ Standard Open Inflation Package
 """
 # Импорт основных классов из модульной структуры
 from .models import HttpMethod, Response, Request, Cookie
+from .execute import Execute, ExecuteAction
 from .browser import BaseAPI
 from .browser_engines import (
     BrowserEngine,
@@ -17,7 +18,7 @@ from .browser_engines import (
 from .page import Page
 
 # Версия пакета
-__version__ = "0.1.7.1"
+__version__ = "0.1.8"
 
 # Публичный API
 __all__ = [
@@ -33,5 +34,7 @@ __all__ = [
     'Request',
     'Response',
     'HttpMethod',
-    'Cookie'
+    'Cookie',
+    'Execute',
+    'ExecuteAction'
 ]

--- a/standard_open_inflation_package/execute.py
+++ b/standard_open_inflation_package/execute.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum, auto
+from typing import Callable, Awaitable, Optional, Union
+
+from beartype import beartype
+
+# Forward declaration for type checking without circular import
+from typing import TYPE_CHECKING
+if TYPE_CHECKING:
+    from .models import Response
+
+
+class ExecuteAction(Enum):
+    """Actions available for Handler execution."""
+
+    RETURN = auto()
+    MODIFY = auto()
+    ALL = auto()
+
+
+@beartype
+@dataclass(frozen=True)
+class Execute:
+    """Configuration for Handler behaviour."""
+
+    action: ExecuteAction
+    callback: Optional[Callable[["Response"], Union["Response", Awaitable["Response"]]]] = None
+    max_responses: Optional[int] = None
+    max_modifications: Optional[int] = None
+
+    def __post_init__(self) -> None:
+        if self.action == ExecuteAction.RETURN:
+            # For RETURN only max_responses is relevant
+            if self.callback is not None:
+                raise ValueError("RETURN action should not have a callback")
+        elif self.action == ExecuteAction.MODIFY:
+            if self.callback is None:
+                raise ValueError("MODIFY action requires a callback")
+            if self.max_modifications is None:
+                raise ValueError("MODIFY action requires max_modifications")
+        elif self.action == ExecuteAction.ALL:
+            if self.callback is None:
+                raise ValueError("ALL action requires a callback")
+            if self.max_modifications is None:
+                raise ValueError("ALL action requires max_modifications")
+            if self.max_responses is None:
+                raise ValueError("ALL action requires max_responses")
+
+    # Convenient constructors
+    @classmethod
+    def RETURN(cls, max_responses: Optional[int] = 1) -> "Execute":
+        return cls(action=ExecuteAction.RETURN, max_responses=max_responses)
+
+    @classmethod
+    def MODIFY(
+        cls,
+        callback: Callable[["Response"], Union["Response", Awaitable["Response"]]],
+        max_modifications: Optional[int] = 1,
+    ) -> "Execute":
+        return cls(
+            action=ExecuteAction.MODIFY,
+            callback=callback,
+            max_modifications=max_modifications,
+        )
+
+    @classmethod
+    def ALL(
+        cls,
+        callback: Callable[["Response"], Union["Response", Awaitable["Response"]]],
+        max_responses: Optional[int] = 1,
+        max_modifications: Optional[int] = 1,
+    ) -> "Execute":
+        return cls(
+            action=ExecuteAction.ALL,
+            callback=callback,
+            max_responses=max_responses,
+            max_modifications=max_modifications,
+        )

--- a/standard_open_inflation_package/models.py
+++ b/standard_open_inflation_package/models.py
@@ -114,7 +114,7 @@ class HttpMethod(Enum):
 
 
 @beartype
-@dataclass(frozen=True)
+@dataclass(frozen=False)
 class Response:
     """Класс для представления ответа от API"""
     

--- a/standard_open_inflation_package/page.py
+++ b/standard_open_inflation_package/page.py
@@ -11,6 +11,7 @@ from . import config as CFG
 from .models import Response, Request, HttpMethod, Cookie
 from .exceptions import NetworkError
 from .handler import Handler, HandlerSearchFailed, HandlerSearchSuccess
+from .execute import Execute
 from .direct_request_interceptor import MultiRequestInterceptor
 
 
@@ -281,7 +282,7 @@ class Page:
         request_interceptor_handler = Handler.ALL(
             startswith_url=final_request.real_url,
             method=final_request.method,
-            max_responses=1 # Нам нужен только один запрос
+            execute=Execute.RETURN(1)  # Нам нужен только один запрос
         )
         
         self.API._logger.info(CFG.LOGS.INJECT_FETCH_INTERCEPTOR_SETUP.format(url=final_request.real_url))

--- a/tests/api/interceptor_tests.py
+++ b/tests/api/interceptor_tests.py
@@ -1,5 +1,6 @@
 import pytest
 from standard_open_inflation_package.handler import Handler, ExpectedContentType
+from standard_open_inflation_package.execute import Execute
 from io import BytesIO
 
 # Импортируем утилиты для тестирования
@@ -133,9 +134,10 @@ async def test_interceptor_max_responses():
     """Тест ANY handler'а - ожидаем множественные любые ответы"""
     max_resp = [1, 2, 3]  # Максимальное количество ответов, которые мы хотим перехватить
     async with api_session(DEFAULT_TIMEOUT) as api:
-        results = await api.new_direct_fetch(CHECK_HTML_PAGE, handlers=[
-            Handler.ALL(max_responses=max_resp[i]) for i in range(len(max_resp))
-        ])
+        results = await api.new_direct_fetch(
+            CHECK_HTML_PAGE,
+            handlers=[Handler.ALL(execute=Execute.RETURN(max_resp[i])) for i in range(len(max_resp))],
+        )
         assert len(results) == len(max_resp), f"Expected {len(max_resp)} result, got {len(results)}"
         result = results[0]
         


### PR DESCRIPTION
## Summary
- make `Response` mutable
- add new `Execute` configuration for handlers
- support MODIFY/ALL actions in interceptor
- use Execute in handler constructors and in page's fetch helper
- update tests for new API

## Testing
- `pytest tests/api/interceptor_tests.py::test_interceptor_max_responses -q` *(fails: BrowserType.launch executable missing)*

------
https://chatgpt.com/codex/tasks/task_e_684dae47cf10832fbdccb718d7f3bb24